### PR TITLE
Cache Gravatar Images

### DIFF
--- a/streaming-optimizations/streaming-optimizations.js
+++ b/streaming-optimizations/streaming-optimizations.js
@@ -127,6 +127,7 @@ const STYLESHEET_URLS = [
 PROXY_DOMAINS = [
   'cdn\\.shopify\\.com',
   'cdn[\\d]*\\.bigcommerce\\.com',
+  'secure\\.gravatar\\.com',
   'i[\\d]+\\.wp\\.com',
   'static[\\d]*\\.squarespace\\.com'
 ];


### PR DESCRIPTION
Adds the ability for gravatar images to be cached. (tested it on my live site and it's working as expected)

Example page: https://www.sertmedia.com/how-to-disable-the-woocommerce-status-widget/